### PR TITLE
Specify 'Class::Accessor::Lite' version

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,5 @@
 requires 'perl', '5.008001';
-requires 'Class::Accessor::Lite';
+requires 'Class::Accessor::Lite', '0.05';
 
 on 'test' => sub {
     requires 'Test::More', '0.98';


### PR DESCRIPTION
Because Router::Boom::Node requires 'Class::Accessor:Lite@0.05'.
