### PR TITLE
Add/allowed methods

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -3,5 +3,6 @@ requires 'Class::Accessor::Lite', '0.05';
 
 on 'test' => sub {
     requires 'Test::More', '0.98';
+    requires 'Test::Deep';
 };
 

--- a/lib/Router/Boom/Method.pm
+++ b/lib/Router/Boom/Method.pm
@@ -124,7 +124,7 @@ C<$path> is the path string. It will be matching with the C<PATH_INFO>.
 
 C<$opaque> is the destination path data. Any data is OK.
 
-=item C<< my ($dest, $captured, $is_method_not_allowed) = $router->match($http_method:Str, $path:Str) >>
+=item C<< my ($dest, $captured, $is_method_not_allowed, $allowed_methods) = $router->match($http_method:Str, $path:Str) >>
 
 Matching with the router.
 
@@ -139,6 +139,8 @@ If the request is not matching with any path, this method returns empty list.
 If the request is matched well then, return C<$dest>, C<$captured>. And C<$is_method_not_allowed> is false value.
 
 If the request path is matched but the C<$http_method> is not matched, then C<$dest> and C<$captured> is undef. And C<$is_method_not_allowed> is true value. You got this then you need to return C<405 Method Not Allowed> error.
+
+If the request path is matched but the C<$http_method> is not matched, then C<$dest> and C<$captured> is undef. And C<$allowed_methods> is ArrayRef. You got this then you need to return C<405 Method Not Allowed> error with C<Allow> header.
 
 =item C<< my $regexp = $router->regexp() >>
 

--- a/lib/Router/Boom/Method.pm
+++ b/lib/Router/Boom/Method.pm
@@ -58,12 +58,14 @@ sub match {
     $self->{router} ||= $self->_build_router();
 
     if (my ($patterns, $captured) = $self->{router}->match($path)) {
+        my @allowed_methods;
         for my $pattern (@$patterns) {
             if (_method_match($request_method, $pattern->[0])) {
-                return ($pattern->[1], $captured, 0);
+                return ($pattern->[1], $captured, 0, []);
             }
+            push @allowed_methods, @{$pattern->[0]};
         }
-        return (undef, undef, 1);
+        return (undef, undef, 1, \@allowed_methods);
     } else {
         return;
     }

--- a/t/03_method.t
+++ b/t/03_method.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 use utf8;
 use Test::More;
+use Test::Deep;
 use Router::Boom::Method;
 
 my $r = Router::Boom::Method->new();
@@ -16,51 +17,65 @@ subtest 'GET /' => sub {
 };
 
 subtest 'GET /a' => sub {
-    my ($a,$b,$c) = $r->match('GET', '/a');
+    my ($a,$b,$c,$d) = $r->match('GET', '/a');
     is $a, 'g';
     is_deeply $b, {};
     is $c, 0;
+    cmp_deeply $d, [];
 };
 subtest 'POST /a' => sub {
-    my ($a,$b,$c) = $r->match('POST', '/a');
+    my ($a,$b,$c,$d) = $r->match('POST', '/a');
     is $a, 'p';
     is_deeply $b, {};
     is $c, 0;
+    cmp_deeply $d, [];
 };
 
-subtest 'GET /b' => sub {
-    my ($a,$b,$c) = $r->match('POST', '/b');
-    is $a, 'any';
-    is_deeply $b, {};
-    is $c, 0;
-};
-
-subtest 'GET /c' => sub {
-    my ($a,$b,$c) = $r->match('GET', '/c');
-    is $a, 'get only';
-    is_deeply $b, {};
-    is $c, 0;
-};
-
-subtest 'POST /c' => sub {
-    my ($a,$b,$c) = $r->match('POST', '/c');
+subtest '/a' => sub {
+    my ($a,$b,$c,$d) = $r->match('HEAD', '/a');
     is $a, undef;
     is_deeply $b, undef;
     is $c, 1;
+    cmp_deeply $d, bag('GET', 'POST');
+};
+
+subtest 'GET /b' => sub {
+    my ($a,$b,$c,$d) = $r->match('POST', '/b');
+    is $a, 'any';
+    is_deeply $b, {};
+    is $c, 0;
+    cmp_deeply $d, [];
+};
+
+subtest 'GET /c' => sub {
+    my ($a,$b,$c,$d) = $r->match('GET', '/c');
+    is $a, 'get only';
+    is_deeply $b, {};
+    is $c, 0;
+    cmp_deeply $d, [];
+};
+
+subtest 'POST /c' => sub {
+    my ($a,$b,$c,$d) = $r->match('POST', '/c');
+    is $a, undef;
+    is_deeply $b, undef;
+    is $c, 1;
+    cmp_deeply $d, bag('GET');
 };
 
 subtest '/d' => sub {
     subtest 'GET' => sub {
-        my ($a,$b,$c) = $r->match('GET', '/d');
+        my ($a,$b,$c,$d) = $r->match('GET', '/d');
         is $a, 'get/head';
     };
     subtest 'HEAD' => sub {
-        my ($a,$b,$c) = $r->match('HEAD', '/d');
+        my ($a,$b,$c,$d) = $r->match('HEAD', '/d');
         is $a, 'get/head';
     };
     subtest 'POST' => sub {
-        my ($a,$b,$c) = $r->match('POST', '/d');
+        my ($a,$b,$c,$d) = $r->match('POST', '/d');
         is $a, undef;
+        cmp_deeply $d, bag('GET', 'HEAD');
     };
 };
 

--- a/t/03_method.t
+++ b/t/03_method.t
@@ -31,7 +31,7 @@ subtest 'POST /a' => sub {
     cmp_deeply $d, [];
 };
 
-subtest '/a' => sub {
+subtest 'HEAD /a' => sub {
     my ($a,$b,$c,$d) = $r->match('HEAD', '/a');
     is $a, undef;
     is_deeply $b, undef;


### PR DESCRIPTION
@tokuhirom さん

https://tools.ietf.org/html/rfc7231#section-6.5.5 によると、
 `405 Method Not Allowed` の際には、`Allow` header を返すことを MUST としているようです。
現在のインタフェースだと、許可される method が取れないようなので、PR のような修正をしてみました。

もしよろしければ取り込みをお願い致します。
